### PR TITLE
Add tile server url option

### DIFF
--- a/src/coffee/init.coffee
+++ b/src/coffee/init.coffee
@@ -16,6 +16,7 @@ crosslet.changeSelect= (select, val) ->
 crosslet.defaultConfig=
 		map:
 			leaflet:
+				url: "http://{s}.tile.cloudmade.com/{key}/{styleId}/256/{z}/{x}/{y}.png" #Tiles server's url
 				key: "--your key--" #Obtain your own key at http://developers.cloudmade.com/projects
 				styleId: 64657 #Get any style from here: http://maps.cloudmade.com/editor
 				attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://cloudmade.com">CloudMade</a>'

--- a/src/coffee/views/mapView.coffee
+++ b/src/coffee/views/mapView.coffee
@@ -11,8 +11,8 @@ class crosslet.MapView extends Backbone.View
 		@hoverFunc=@default_hover
 		$(@el).attr("class","crosslet")
 		@map= L.map(el[0]).setView(@config.map.view.center, @config.map.view.zoom)
-	
-		L.tileLayer("http://{s}.tile.cloudmade.com/{key}/{styleId}/256/{z}/{x}/{y}.png", @config.map.leaflet).addTo(@map);
+
+		L.tileLayer(@config.map.leaflet.url, @config.map.leaflet).addTo(@map);
 		@control=$("<div class='crosslet_panel'></div>")
 		
 		@info = L.Control.extend(


### PR DESCRIPTION
Hi,
Here is a very simple patch that permits the choice of the tile server. It just add a "url" option to map.leaflet configuration and use it at TileLayer creation.

I think it's nice to offer this option to avoid the need of a cloudmade API key.
For exemple, I use the tile server url "http://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png" and set the attribution to "Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://www.openstreetmap.org/copyright">ODbL</a>, Imagery © <a href="http://openstreetmap.fr">OSM_Fr</a>"
