### PR TITLE
Update leaflet to 0.7.2

### DIFF
--- a/examples/census/index.html
+++ b/examples/census/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/examples/census/index_wherefrom.html
+++ b/examples/census/index_wherefrom.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.4/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/examples/happiness/index.html
+++ b/examples/happiness/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.4/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/examples/nhs/index.html
+++ b/examples/nhs/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/examples/ukraine/index.html
+++ b/examples/ukraine/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 <style>
 -webkit-touch-callout: none;
 -webkit-user-select: none;

--- a/examples/us/index.html
+++ b/examples/us/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/examples/world/index.html
+++ b/examples/world/index.html
@@ -13,8 +13,8 @@
     
     <link rel="stylesheet/less" type="text/css" href="less/styles.less" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/1.3.1/less.min.js" type="text/javascript"></script>
-     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4/leaflet.css" />
-     <script src="http://cdn.leafletjs.com/leaflet-0.4.4/leaflet.js"></script>
+     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+     <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
     <link href="css/bootstrap-responsive.css" rel="stylesheet">
     <link href="css/styles.css" rel="stylesheet">
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
     <link rel="stylesheet" href="css/crosslet.css" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
@@ -148,7 +148,7 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <script src="js/bootstrap.js"></script>
-<script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+<script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet-src.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.2/underscore-min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.0.1/d3.v3.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.2/backbone-min.js"></script>


### PR DESCRIPTION
All examples are still functioning after update to 0.7.2. This will fix the drunk zoom problem and allow for additional map pane options.
